### PR TITLE
fix: GitHub Actions でDBのコネクションが不安定な問題を修正

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,6 +9,17 @@ on:
 jobs:
   rspec:
     runs-on: ubuntu-latest
+    services:
+      db:
+        image: mysql:8.0.34-oracle
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: app_test
+    env: 
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: app_test
     steps:
     - uses: actions/checkout@v3
     - name: build and create DB

--- a/compose.rspec.yaml
+++ b/compose.rspec.yaml
@@ -2,13 +2,19 @@ services:
   app:
     environment:
       - RAILS_ENV=test
+      - MYSQL_HOST=127.0.0.1
     build:
       context: .
       dockerfile: ./Dockerfile
     image: "tkycraft/mahirun:rspec1.0"
+    depends_on: {}
     volumes: []
     healthcheck: {}
     entrypoint: []
+    network_mode: host
 
   mysql:
     volumes: []
+    deploy:
+      mode: replicated
+      replicas: 0

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,8 @@ services:
     tty: true
     env_file:
       - ./.env
+    environment:
+      - MYSQL_HOST=mysql
     depends_on:
       mysql:
         condition: service_healthy

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV["MYSQL_DATABASE"] %>
   password: <%= ENV["MYSQL_ROOT_PASSWORD"] %>
-  host: mysql
+  host: <%= ENV["MYSQL_HOST"] %>
 
 development:
   <<: *default


### PR DESCRIPTION
## Issue
close #24 

## 変更概要
- workflow で MySQL コンテナを作成するよう指定
- compose.rspec.yaml にActionsのときのネットワーク設定を追記
- config/database.yaml でdbのホストを環境変数での指定に変更

## メモ
- Actionsのホストランナー自身のMySQLでもDBのコネクションが怪しかった。
- Actionsのworkflowにserviceとして定義したDBへの名前解決方法が不明...