### PR TITLE
change default database charset and collection

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,6 +15,8 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
+  charset: utf8mb4
+  collation: utf8mb4_bin
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV["MYSQL_DATABASE"] %>
   password: <%= ENV["MYSQL_ROOT_PASSWORD"] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2023_07_19_151017) do
-  create_table "servers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "servers", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "discord_server_id", null: false
     t.integer "music_volume", default: 5, null: false
     t.boolean "is_read_unconnected_user_message", default: false, null: false


### PR DESCRIPTION
## Issues
close #6 

## 変更
- default charset と collection を指定
- schema の変更

## 背景
- `utf8mb4_0900_ai_ci` がRailsのdefaultのcharsetだが、 `utf8mb4_bin` に比較して癖が強いかもしれない
	- 絵文字の扱い (辞書機能を実装するときに影響しそう)
	- SQLで文字列を比較したいケースがでたとき「ば」「ぱ」が同一の判断になってしまう。

影響範囲
- 全 Migration file
- schema
- config/database.yaml

## 変更内容の確認
- ローカルでの何度かの DBのdrop / migrate のしなおし
- CI でのチェック