### PR TITLE
fix: Dockerfile の 命令文の途中での空行は非推奨

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,30 +3,19 @@ FROM ruby:3.2.2-slim-bullseye
 WORKDIR /opt/app
 
 RUN \
-
 # install apt package.
 	apt-get update \
 	&& apt-get install -y \
 		build-essential \
 		curl \
-
-		# for sqlite
-		# libsqlite3-dev \
-
-		# for mysql or maria-db
+	# for mysql or maria-db
 		libmariadb-dev \
-
-		# when creating rails project.
-		# git \
-
 # clear apt cache.
 	&& apt-get clean -y \
 	&& rm -rf /var/lib/apt/lists/* \
-
 # add alias
 	&& echo "gem: --no-document" >> ~/.gemrc \
 	&& echo "alias ll='ls -la'" >> ~/.bashrc \
-
 # install rails / bundler
 	&& which gem \
 	&& gem install rails -v 7.0.4 \


### PR DESCRIPTION
fix #33 
delete unnecessary empty lines of Dockerfile.

## 変更確認項目
- ローカルで該当のwarningが表示されなくなったことを確認
- GitHub Actions で該当のwarningが表示されなくなったことを[確認](https://github.com/TKYcraft/mahirun/actions/runs/5891894881/job/15979987926?pr=34)

## Issue
### [fix] Dockerfile の 命令文の途中での空行は非推奨

タイトルの通り
現在非推奨で、今後廃止(動作しなくなる)予定の模様 

すでにWARNINGが出ています。
https://github.com/TKYcraft/mahirun/actions/runs/5815339596/job/15979421026#step:4:29