### PR TITLE
fix: replace `docker-compose` command to `docker compose`

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,12 +25,12 @@ jobs:
     - name: build and create DB
       shell: bash
       run: |
-        docker-compose -f compose.yaml -f compose.rspec.yaml build
-        docker-compose -f compose.yaml -f compose.rspec.yaml run app rails db:create
+        docker compose -f compose.yaml -f compose.rspec.yaml build
+        docker compose -f compose.yaml -f compose.rspec.yaml run app rails db:create
       env:
         RAILS_ENV: test
     - name: exec rspec
       run:  |
-        docker-compose -f compose.yaml -f compose.rspec.yaml run app bundle exec rspec
+        docker compose -f compose.yaml -f compose.rspec.yaml run app bundle exec rspec
       env:
         RAILS_ENV: test


### PR DESCRIPTION
## summary
- replace `docker-compose` command to `docker compose`.
- old `docker-compose` [command is removed from Actions Runner Image](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2).

## issues
- close #107 